### PR TITLE
Adapt for Qtum and rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
-name = "bech32"
+name = "bech32-qtum"
 version = "0.10.0-beta"
-authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding"]
-repository = "https://github.com/rust-bitcoin/rust-bech32"
+authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding", "The Qtum developers"]
+repository = "https://github.com/qtumproject/rust-bech32"
 documentation = "https://docs.rs/bech32/"
 description = "Encodes and decodes the Bech32 format and implements the bech32 and bech32m checksums"
 readme = "README.md"
-keywords = ["base32", "encoding", "bech32", "bitcoin", "cryptocurrency"]
+keywords = ["base32", "encoding", "bech32", "bitcoin", "qtum", "cryptocurrency"]
 categories = ["encoding", "cryptography::cryptocurrencies"]
 license = "MIT"
 edition = "2018"
+autotests = false
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+Rust Bech32 Qtum
+================
+
+Rust implementation of the Bech32 encoding format for Qtum. This repository was forked from [rust-bech32](https://github.com/rust-bitcoin/rust-bech32).
+
+See below for the original `rust-bech32` README.
+
+---
+
 Rust Bech32
 ===========
 

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -8,6 +8,7 @@
 #![no_std]
 
 use arrayvec::ArrayString;
+use bech32_qtum as bech32;
 use bech32::primitives::decode::CheckedHrpstring;
 use bech32::{Bech32, Hrp};
 use cortex_m_rt::entry;

--- a/embedded/with-allocator/src/main.rs
+++ b/embedded/with-allocator/src/main.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 use core::alloc::Layout;
 
 use alloc_cortex_m::CortexMHeap;
+use bech32_qtum as bech32;
 use bech32::{Bech32m, Hrp};
 use cortex_m::asm;
 use cortex_m_rt::entry;

--- a/fuzz/fuzz_targets/encode_decode.rs
+++ b/fuzz/fuzz_targets/encode_decode.rs
@@ -2,6 +2,7 @@ extern crate bech32;
 
 use std::str;
 
+use bech32_qtum as bech32;
 use bech32::{Bech32m, Hrp};
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/parse_hrp.rs
+++ b/fuzz/fuzz_targets/parse_hrp.rs
@@ -1,5 +1,6 @@
 extern crate bech32;
 
+use bech32_qtum as bech32;
 use bech32::Hrp;
 
 fn do_test(data: &[u8]) {

--- a/src/hrp.rs
+++ b/src/hrp.rs
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
 
 #[doc(inline)]
-pub use crate::primitives::hrp::{Hrp, BC, BCRT, TB};
+pub use crate::primitives::hrp::{Hrp, QC, QCRT, TQ};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,15 +39,15 @@
 //!
 //! const DATA: [u8; 20] = [0xab; 20]; // Arbitrary data to be encoded.
 //! const STRING: &str = "abc14w46h2at4w46h2at4w46h2at4w46h2at958ngu";
-//! const TAP_ADDR: &str = "bc1p4w46h2at4w46h2at4w46h2at4w46h2at5kreae";
+//! const TAP_ADDR: &str = "qc1p4w46h2at4w46h2at4w46h2at4w46h2atc9q4ar";
 //!
 //! // Encode arbitrary data using "abc" as the human-readable part and append a bech32m checksum.
 //! let hrp = Hrp::parse("abc").expect("valid hrp");
 //! let string = bech32::encode::<Bech32m>(hrp, &DATA).expect("failed to encode string");
 //! assert_eq!(string, STRING);
 //!
-//! // Encode arbitrary data as a Bitcoin taproot address.
-//! let taproot_address = segwit::encode(hrp::BC, segwit::VERSION_1, &DATA).expect("valid witness version and program");
+//! // Encode arbitrary data as a Qtum taproot address.
+//! let taproot_address = segwit::encode(hrp::QC, segwit::VERSION_1, &DATA).expect("valid witness version and program");
 //! assert_eq!(taproot_address, TAP_ADDR);
 //!
 //! // No-alloc: Encode without allocating (ignoring that String::new() allocates :).
@@ -66,7 +66,7 @@
 //!
 //! const DATA: [u8; 20] = [0xab; 20]; // Arbitrary data to be encoded.
 //! const STRING: &str = "abc14w46h2at4w46h2at4w46h2at4w46h2at958ngu";
-//! const TAP_ADDR: &str = "bc1p4w46h2at4w46h2at4w46h2at4w46h2at5kreae";
+//! const TAP_ADDR: &str = "qc1p4w46h2at4w46h2at4w46h2at4w46h2atc9q4ar";
 //!
 //! // Decode a bech32 encoded string that includes a bech32/bech32m checksum.
 //! //
@@ -576,19 +576,19 @@ mod tests {
     use crate::{Bech32, Bech32m};
 
     // Tests below using this data, are based on the test vector (from BIP-173):
-    // BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4: 0014751e76e8199196d454941c45d1b3a323f1433bd6
+    // QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT: 0014f1b43c26b1704aea714b847f12011c3e88d46954
     #[rustfmt::skip]
     const DATA: [u8; 20] = [
-        0xff, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
-        0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
-        0xf1, 0x43, 0x3b, 0xd6,
+        0xff, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea,
+        0x71, 0x4b, 0x84, 0x7f, 0x12, 0x01, 0x1c, 0x3e,
+        0x88, 0xd4, 0x69, 0x54,
     ];
 
     #[test]
     fn encode_bech32m() {
         let hrp = Hrp::parse_unchecked("test");
         let got = encode::<Bech32m>(hrp, &DATA).expect("failed to encode");
-        let want = "test1lu08d6qejxtdg4y5r3zarvary0c5xw7kmz4lky";
+        let want = "test1l76rcf43wp9w5u2ts3l3yqgu86ydg625tep5f8";
         assert_eq!(got, want);
     }
 
@@ -596,7 +596,7 @@ mod tests {
     fn encode_bech32_lower() {
         let hrp = Hrp::parse_unchecked("test");
         let got = encode_lower::<Bech32>(hrp, &DATA).expect("failed to encode");
-        let want = "test1lu08d6qejxtdg4y5r3zarvary0c5xw7kw79nnx";
+        let want = "test1l76rcf43wp9w5u2ts3l3yqgu86ydg625793cv9";
         assert_eq!(got, want);
     }
 
@@ -608,7 +608,7 @@ mod tests {
         encode_lower_to_writer::<Bech32, _>(&mut buf, hrp, &DATA).expect("failed to encode");
 
         let got = std::str::from_utf8(&buf).expect("ascii is valid utf8");
-        let want = "test1lu08d6qejxtdg4y5r3zarvary0c5xw7kw79nnx";
+        let want = "test1l76rcf43wp9w5u2ts3l3yqgu86ydg625793cv9";
         assert_eq!(got, want);
     }
 
@@ -616,7 +616,7 @@ mod tests {
     fn encode_bech32_upper() {
         let hrp = Hrp::parse_unchecked("test");
         let got = encode_upper::<Bech32>(hrp, &DATA).expect("failed to encode");
-        let want = "TEST1LU08D6QEJXTDG4Y5R3ZARVARY0C5XW7KW79NNX";
+        let want = "TEST1L76RCF43WP9W5U2TS3L3YQGU86YDG625793CV9";
         assert_eq!(got, want);
     }
 
@@ -628,13 +628,13 @@ mod tests {
         encode_upper_to_writer::<Bech32, _>(&mut buf, hrp, &DATA).expect("failed to encode");
 
         let got = std::str::from_utf8(&buf).expect("ascii is valid utf8");
-        let want = "TEST1LU08D6QEJXTDG4Y5R3ZARVARY0C5XW7KW79NNX";
+        let want = "TEST1L76RCF43WP9W5U2TS3L3YQGU86YDG625793CV9";
         assert_eq!(got, want);
     }
 
     #[test]
     fn decode_bech32m() {
-        let s = "test1lu08d6qejxtdg4y5r3zarvary0c5xw7kmz4lky";
+        let s = "test1l76rcf43wp9w5u2ts3l3yqgu86ydg625tep5f8";
         let (hrp, data) = decode(s).expect("failed to encode");
 
         assert_eq!(hrp, Hrp::parse_unchecked("test"));
@@ -643,7 +643,7 @@ mod tests {
 
     #[test]
     fn decode_bech32_lower() {
-        let s = "test1lu08d6qejxtdg4y5r3zarvary0c5xw7kw79nnx";
+        let s = "test1l76rcf43wp9w5u2ts3l3yqgu86ydg625793cv9";
         let (hrp, data) = decode(s).expect("failed to encode");
 
         assert_eq!(hrp, Hrp::parse_unchecked("test"));
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn decode_bech32_upper() {
-        let s = "TEST1LU08D6QEJXTDG4Y5R3ZARVARY0C5XW7KW79NNX";
+        let s = "TEST1L76RCF43WP9W5U2TS3L3YQGU86YDG625793CV9";
         let (hrp, data) = decode(s).expect("failed to encode");
 
         assert_eq!(hrp, Hrp::parse_unchecked("TEST"));
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn encoded_length_works() {
-        let s = "test1lu08d6qejxtdg4y5r3zarvary0c5xw7kmz4lky";
+        let s = "test1l76rcf43wp9w5u2ts3l3yqgu86ydg625tep5f8";
         let (hrp, data) = decode(s).expect("valid string");
 
         let encoded = encode::<Bech32m>(hrp, &data).expect("valid data");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //!
 //! ```
 //! # #[cfg(feature = "alloc")] {
+//! use bech32_qtum as bech32;
 //! use bech32::{hrp, segwit, Hrp, Bech32m};
 //!
 //! const DATA: [u8; 20] = [0xab; 20]; // Arbitrary data to be encoded.
@@ -61,6 +62,7 @@
 //!
 //! ```
 //! # #[cfg(feature = "alloc")] {
+//! use bech32_qtum as bech32;
 //! use bech32::primitives::decode::{CheckedHrpstring, SegwitHrpstring};
 //! use bech32::{hrp, segwit, Hrp, Bech32m};
 //!
@@ -97,6 +99,7 @@
 //!
 //! ```
 //! # #[cfg(feature = "alloc")] {
+//! use bech32_qtum as bech32;
 //! use bech32::Checksum;
 //!
 //! /// The codex32 checksum algorithm, defined in BIP-93.
@@ -189,6 +192,7 @@ const BUF_LENGTH: usize = 10;
 /// # Examples
 /// ```
 /// # #[cfg(feature = "alloc")] {
+/// use bech32_qtum as bech32;
 /// use bech32::{decode, Bech32, Bech32m, NoChecksum};
 /// use bech32::primitives::decode::CheckedHrpstring;
 ///

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -33,6 +33,7 @@
 //! # Examples
 //!
 //! ```
+//! use bech32_qtum as bech32;
 //! use bech32::{Bech32, Bech32m, Fe32, Hrp};
 //! use bech32::primitives::decode::{CheckedHrpstring, SegwitHrpstring, UncheckedHrpstring};
 //! use bech32::segwit::VERSION_1;
@@ -97,6 +98,7 @@ const SEP: char = '1';
 /// # Examples
 ///
 /// ```
+/// use bech32_qtum as bech32;
 /// use bech32::{Bech32, Bech32m, primitives::decode::UncheckedHrpstring};
 ///
 /// let addr = "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT";
@@ -236,6 +238,7 @@ impl<'s> UncheckedHrpstring<'s> {
 /// # Examples
 ///
 /// ```
+/// use bech32_qtum as bech32;
 /// use bech32::{Bech32m, primitives::decode::CheckedHrpstring};
 ///
 /// // Parse a general checksummed bech32 encoded string.
@@ -359,6 +362,7 @@ impl<'s> CheckedHrpstring<'s> {
 /// # Examples
 ///
 /// ```
+/// use bech32_qtum as bech32;
 /// use bech32::primitives::decode::SegwitHrpstring;
 ///
 /// // Parse a segwit V0 address.

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -99,7 +99,7 @@ const SEP: char = '1';
 /// ```
 /// use bech32::{Bech32, Bech32m, primitives::decode::UncheckedHrpstring};
 ///
-/// let addr = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+/// let addr = "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT";
 /// let unchecked = UncheckedHrpstring::new(addr).expect("valid bech32 character encoded string");
 /// if unchecked.has_valid_checksum::<Bech32>() {
 ///     // Remove the checksum and do something with the data.
@@ -1007,9 +1007,9 @@ mod tests {
 
     #[test]
     fn check_hrp_uppercase_returns_lower() {
-        let addr = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+        let addr = "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT";
         let unchecked = UncheckedHrpstring::new(addr).expect("failed to parse address");
-        assert_eq!(unchecked.hrp(), Hrp::parse_unchecked("bc"));
+        assert_eq!(unchecked.hrp(), Hrp::parse_unchecked("qc"));
     }
 
     #[test]

--- a/src/primitives/encode.rs
+++ b/src/primitives/encode.rs
@@ -14,6 +14,7 @@
 //! # Examples
 //!
 //! ```
+//! use bech32_qtum as bech32;
 //! use bech32::{Bech32, ByteIterExt, Fe32IterExt, Fe32, Hrp};
 //!
 //! let witness_prog = [
@@ -57,6 +58,7 @@ use crate::{Checksum, Fe32};
 /// # Examples
 ///
 /// ```
+/// use bech32_qtum as bech32;
 /// use bech32::{Bech32, ByteIterExt, Fe32IterExt, Hrp};
 ///
 /// let data = [0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea];

--- a/src/primitives/encode.rs
+++ b/src/primitives/encode.rs
@@ -17,14 +17,14 @@
 //! use bech32::{Bech32, ByteIterExt, Fe32IterExt, Fe32, Hrp};
 //!
 //! let witness_prog = [
-//!     0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
-//!     0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
-//!     0xf1, 0x43, 0x3b, 0xd6,
+//!     0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea,
+//!     0x71, 0x4b, 0x84, 0x7f, 0x12, 0x01, 0x1c, 0x3e,
+//!     0x88, 0xd4, 0x69, 0x54,
 //! ];
 //!
 //! // Get a stream of characters representing the bech32 encoded
 //! // address using "bc" for the human-readable part.
-//! let hrp = Hrp::parse("bc").expect("bc is valid hrp string");
+//! let hrp = Hrp::parse("qc").expect("qc is valid hrp string");
 //! let chars = witness_prog
 //!     .iter()
 //!     .copied()
@@ -36,7 +36,7 @@
 //! #[cfg(feature = "alloc")]
 //! {
 //!     let addr = chars.collect::<String>();
-//!     assert_eq!(addr.to_uppercase(), "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4");
+//!     assert_eq!(addr.to_uppercase(), "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT");
 //! }
 //! ```
 
@@ -59,7 +59,7 @@ use crate::{Checksum, Fe32};
 /// ```
 /// use bech32::{Bech32, ByteIterExt, Fe32IterExt, Hrp};
 ///
-/// let data = [0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4];
+/// let data = [0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea];
 ///
 /// let hrp = Hrp::parse("abc").expect("bc is valid hrp string");
 /// let chars = data
@@ -348,22 +348,22 @@ mod tests {
     use crate::{Bech32, ByteIterExt, Fe32, Fe32IterExt, Hrp};
 
     // Tests below using this data, are based on the test vector (from BIP-173):
-    // BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4: 0014751e76e8199196d454941c45d1b3a323f1433bd6
+    // QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT: 0014f1b43c26b1704aea714b847f12011c3e88d46954
     #[rustfmt::skip]
     const DATA: [u8; 20] = [
-        0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
-        0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
-        0xf1, 0x43, 0x3b, 0xd6,
+        0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea,
+        0x71, 0x4b, 0x84, 0x7f, 0x12, 0x01, 0x1c, 0x3e,
+        0x88, 0xd4, 0x69, 0x54,
     ];
 
     #[test]
     fn hrpstring_iter() {
         let iter = DATA.iter().copied().bytes_to_fes();
 
-        let hrp = Hrp::parse_unchecked("bc");
+        let hrp = Hrp::parse_unchecked("qc");
         let iter = iter.with_checksum::<Bech32>(&hrp).with_witness_version(Fe32::Q).chars();
 
-        assert!(iter.eq("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".chars()));
+        assert!(iter.eq("qc1q7x6rcf43wp9w5u2ts3l3yqgu86ydg625nf3pft".chars()));
     }
 
     #[test]
@@ -371,11 +371,11 @@ mod tests {
     fn hrpstring_iter_collect() {
         let iter = DATA.iter().copied().bytes_to_fes();
 
-        let hrp = Hrp::parse_unchecked("bc");
+        let hrp = Hrp::parse_unchecked("qc");
         let iter = iter.with_checksum::<Bech32>(&hrp).with_witness_version(Fe32::Q).chars();
 
         let encoded = iter.collect::<String>();
-        assert_eq!(encoded, "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+        assert_eq!(encoded, "qc1q7x6rcf43wp9w5u2ts3l3yqgu86ydg625nf3pft");
     }
 
     #[test]
@@ -383,17 +383,17 @@ mod tests {
         let char_len = "w508d6qejxtdg4y5r3zarvary0c5xw7k".len();
         let iter = DATA.iter().copied().bytes_to_fes();
 
-        let hrp = Hrp::parse_unchecked("bc");
+        let hrp = Hrp::parse_unchecked("qc");
         let iter = iter.with_checksum::<Bech32>(&hrp).with_witness_version(Fe32::Q).chars();
 
-        let checksummed_len = 2 + 1 + 1 + char_len + 6; // bc + SEP + Q + chars + checksum
+        let checksummed_len = 2 + 1 + 1 + char_len + 6; // qc + SEP + Q + chars + checksum
         assert_eq!(iter.size_hint().0, checksummed_len);
     }
 
     #[test]
     #[cfg(feature = "alloc")]
     fn hrpstring_iter_bytes() {
-        let hrp = Hrp::parse_unchecked("bc");
+        let hrp = Hrp::parse_unchecked("qc");
         let fes = DATA.iter().copied().bytes_to_fes();
         let iter = fes.with_checksum::<Bech32>(&hrp).with_witness_version(Fe32::Q);
 

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -19,8 +19,8 @@ use core::{slice, str};
 /// Maximum length of the human-readable part, as defined by BIP-173.
 const MAX_HRP_LEN: usize = 83;
 
-// Defines HRP constants for the different bitcoin networks.
-// You can also access these at `crate::hrp::BC` etc.
+// Defines HRP constants for the different Qtum networks.
+// You can also access these at `crate::hrp::QC` etc.
 #[rustfmt::skip]
 macro_rules! define_hrp_const {
     (
@@ -42,16 +42,16 @@ macro_rules! define_hrp_const {
     };
 }
 define_hrp_const! {
-    /// The human-readable part used by the Bitcoin mainnet network.
-    pub const BC 2 [98, 99, 0, 0];
+    /// The human-readable part used by the Qtum mainnet network.
+    pub const QC 2 [113, 99, 0, 0];
 }
 define_hrp_const! {
-    /// The human-readable part used by the Bitcoin testnet networks (testnet, signet).
-    pub const TB 2 [116, 98, 0, 0];
+    /// The human-readable part used by the Qtum testnet networks (testnet, signet).
+    pub const TQ 2 [116, 113, 0, 0];
 }
 define_hrp_const! {
-    /// The human-readable part used when running a Bitcoin regtest network.
-    pub const BCRT 4 [98, 99, 114, 116];
+    /// The human-readable part used when running a Qtum regtest network.
+    pub const QCRT 4 [113, 99, 114, 116];
 }
 
 /// The human-readable part (human readable prefix before the '1' separator).
@@ -66,7 +66,7 @@ pub struct Hrp {
 impl Hrp {
     /// Parses the human-readable part checking it is valid as defined by [BIP-173].
     ///
-    /// This does _not_ check that the `hrp` is an in-use HRP within Bitcoin (eg, "bc"), rather it
+    /// This does _not_ check that the `hrp` is an in-use HRP within Qtum (eg, "qc"), rather it
     /// checks that the HRP string is valid as per the specification in [BIP-173]:
     ///
     /// > The human-readable part, which is intended to convey the type of data, or anything else that
@@ -194,6 +194,7 @@ impl Hrp {
     /// Returns `true` if this [`Hrp`] is valid according to the bips.
     ///
     /// [BIP-173] states that the HRP must be either "bc" or "tb".
+    /// For Qtum the HRP must be either "qc" or "tq".
     ///
     /// [BIP-173]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Segwit_address_format
     #[inline]
@@ -201,21 +202,21 @@ impl Hrp {
         self.is_valid_on_mainnet() || self.is_valid_on_testnet()
     }
 
-    /// Returns `true` if this hrpstring is valid on the Bitcoin network i.e., HRP is "bc".
+    /// Returns `true` if this hrpstring is valid on the Qtum network i.e., HRP is "qc".
     #[inline]
-    pub fn is_valid_on_mainnet(&self) -> bool { *self == self::BC }
+    pub fn is_valid_on_mainnet(&self) -> bool { *self == self::QC }
 
-    /// Returns `true` if this hrpstring is valid on the Bitcoin testnet network i.e., HRP is "tb".
+    /// Returns `true` if this hrpstring is valid on the Qtum testnet network i.e., HRP is "tq".
     #[inline]
-    pub fn is_valid_on_testnet(&self) -> bool { *self == self::TB }
+    pub fn is_valid_on_testnet(&self) -> bool { *self == self::TQ }
 
-    /// Returns `true` if this hrpstring is valid on the Bitcoin signet network i.e., HRP is "tb".
+    /// Returns `true` if this hrpstring is valid on the Qtum signet network i.e., HRP is "tq".
     #[inline]
-    pub fn is_valid_on_signet(&self) -> bool { *self == self::TB }
+    pub fn is_valid_on_signet(&self) -> bool { *self == self::TQ }
 
-    /// Returns `true` if this hrpstring is valid on the Bitcoin regtest network i.e., HRP is "bcrt".
+    /// Returns `true` if this hrpstring is valid on the Qtum regtest network i.e., HRP is "qcrt".
     #[inline]
-    pub fn is_valid_on_regtest(&self) -> bool { *self == self::BCRT }
+    pub fn is_valid_on_regtest(&self) -> bool { *self == self::QCRT }
 }
 
 /// Displays the human-readable part.
@@ -517,10 +518,10 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn hrp_consts() {
-        use crate::primitives::hrp::{BC, BCRT, TB};
-        assert_eq!(BC, Hrp::parse_unchecked("bc"));
-        assert_eq!(TB, Hrp::parse_unchecked("tb"));
-        assert_eq!(BCRT, Hrp::parse_unchecked("bcrt"));
+        use crate::primitives::hrp::{QC, QCRT, TQ};
+        assert_eq!(QC, Hrp::parse_unchecked("qc"));
+        assert_eq!(TQ, Hrp::parse_unchecked("tq"));
+        assert_eq!(QCRT, Hrp::parse_unchecked("qcrt"));
     }
 
     #[test]

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -13,6 +13,7 @@
 //! # Examples
 //!
 //! ```
+//! use bech32_qtum as bech32;
 //! use bech32::{Bech32, ByteIterExt, Fe32IterExt, Fe32, Hrp};
 //!
 //! let data = [

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -16,9 +16,9 @@
 //! use bech32::{Bech32, ByteIterExt, Fe32IterExt, Fe32, Hrp};
 //!
 //! let data = [
-//!     0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
-//!     0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
-//!     0xf1, 0x43, 0x3b, 0xd6,
+//!     0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea,
+//!     0x71, 0x4b, 0x84, 0x7f, 0x12, 0x01, 0x1c, 0x3e,
+//!     0x88, 0xd4, 0x69, 0x54,
 //! ];
 //!
 //! // Convert byte data to GF32 field elements.
@@ -306,12 +306,12 @@ mod tests {
     use super::*;
 
     // Tests below using this data, are based on the test vector (from BIP-173):
-    // BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4: 0014751e76e8199196d454941c45d1b3a323f1433bd6
+    // QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT: 0014f1b43c26b1704aea714b847f12011c3e88d46954
     #[rustfmt::skip]
     const DATA: [u8; 20] = [
-        0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
-        0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
-        0xf1, 0x43, 0x3b, 0xd6,
+        0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea,
+        0x71, 0x4b, 0x84, 0x7f, 0x12, 0x01, 0x1c, 0x3e,
+        0x88, 0xd4, 0x69, 0x54,
     ];
 
     #[test]
@@ -321,18 +321,18 @@ mod tests {
             .copied()
             .bytes_to_fes()
             .map(Fe32::to_char)
-            .eq("w508d6qejxtdg4y5r3zarvary0c5xw7k".chars()));
+            .eq("7x6rcf43wp9w5u2ts3l3yqgu86ydg625".chars()));
     }
 
     #[test]
     fn bytes_to_fes_size_hint() {
-        let char_len = "w508d6qejxtdg4y5r3zarvary0c5xw7k".len();
+        let char_len = "7x6rcf43wp9w5u2ts3l3yqgu86ydg625".len();
         assert_eq!(DATA.iter().copied().bytes_to_fes().size_hint(), (char_len, Some(char_len)));
     }
 
     #[test]
     fn fe32_iter_ext() {
-        let fe_iter = "w508d6qejxtdg4y5r3zarvary0c5xw7k"
+        let fe_iter = "7x6rcf43wp9w5u2ts3l3yqgu86ydg625"
             .bytes()
             .map(|b| Fe32::from_char(char::from(b)).unwrap());
 
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     fn fes_to_bytes_size_hint() {
-        let fe_iter = "w508d6qejxtdg4y5r3zarvary0c5xw7k"
+        let fe_iter = "7x6rcf43wp9w5u2ts3l3yqgu86ydg625"
             .bytes()
             .map(|b| Fe32::from_char(char::from(b)).unwrap());
 
@@ -354,35 +354,35 @@ mod tests {
     #[test]
     fn padding_bytes_trailing_0_bits_roundtrips() {
         // 5 * 8 % 5 = 0
-        const BYTES: [u8; 5] = [0x75, 0x1e, 0x76, 0xe8, 0x19];
+        const BYTES: [u8; 5] = [0xf1, 0xb4, 0x3c, 0x26, 0xb1];
         assert!(BYTES.iter().copied().bytes_to_fes().fes_to_bytes().eq(BYTES.iter().copied()))
     }
 
     #[test]
     fn padding_bytes_trailing_1_bit_roundtrips() {
         // 2 * 8 % 5 = 1
-        const BYTES: [u8; 2] = [0x75, 0x1e];
+        const BYTES: [u8; 2] = [0xf1, 0xb4];
         assert!(BYTES.iter().copied().bytes_to_fes().fes_to_bytes().eq(BYTES.iter().copied()))
     }
 
     #[test]
     fn padding_bytes_trailing_2_bits_roundtrips() {
         // 4 * 8 % 5 = 2
-        const BYTES: [u8; 4] = [0x75, 0x1e, 0x76, 0xe8];
+        const BYTES: [u8; 4] = [0xf1, 0xb4, 0x3c, 0x26];
         assert!(BYTES.iter().copied().bytes_to_fes().fes_to_bytes().eq(BYTES.iter().copied()))
     }
 
     #[test]
     fn padding_bytes_trailing_3_bits_roundtrips() {
         // 6 * 8 % 5 = 3
-        const BYTES: [u8; 6] = [0x75, 0x1e, 0x76, 0xe8, 0x19, 0xab];
+        const BYTES: [u8; 6] = [0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70];
         assert!(BYTES.iter().copied().bytes_to_fes().fes_to_bytes().eq(BYTES.iter().copied()))
     }
 
     #[test]
     fn padding_bytes_trailing_4_bits_roundtrips() {
         // 3 * 8 % 5 = 4
-        const BYTES: [u8; 3] = [0x75, 0x1e, 0x76];
+        const BYTES: [u8; 3] = [0xf1, 0xb4, 0x3c];
         assert!(BYTES.iter().copied().bytes_to_fes().fes_to_bytes().eq(BYTES.iter().copied()))
     }
 

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -14,23 +14,23 @@
 //! use bech32::{hrp, segwit, Fe32, Hrp};
 //!
 //! let witness_prog = [
-//!     0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
-//!     0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
-//!     0xf1, 0x43, 0x3b, 0xd6,
+//!     0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea,
+//!     0x71, 0x4b, 0x84, 0x7f, 0x12, 0x01, 0x1c, 0x3e,
+//!     0x88, 0xd4, 0x69, 0x54,
 //! ];
 //!
 //! // Encode a taproot address suitable for use on mainnet.
-//! let _ = segwit::encode_v1(hrp::BC, &witness_prog);
+//! let _ = segwit::encode_v1(hrp::QC, &witness_prog);
 //!
 //! // Encode a segwit v0 address suitable for use on testnet.
-//! let _ = segwit::encode_v0(hrp::TB, &witness_prog);
+//! let _ = segwit::encode_v0(hrp::TQ, &witness_prog);
 //!
 //! // If you have the witness version already you can use:
 //! # let witness_version = segwit::VERSION_0;
-//! let _ = segwit::encode(hrp::BC, witness_version, &witness_prog);
+//! let _ = segwit::encode(hrp::QC, witness_version, &witness_prog);
 //!
-//! // Decode a Bitcoin bech32 segwit address.
-//! let address = "bc1q2s3rjwvam9dt2ftt4sqxqjf3twav0gdx0k0q2etxflx38c3x8tnssdmnjq";
+//! // Decode a Qtum bech32 segwit address.
+//! let address = "qc1pya3lkjnz85wr9g9cpmn47lr6w7scmcehym0hs335gagppank5emsfw3aee";
 //! let (hrp, witness_version, witness_program) = segwit::decode(address).expect("failed to decode address");
 //! # }
 //! ```
@@ -436,9 +436,9 @@ mod tests {
     // Just shows we handle both v0 and v1 addresses, for complete test
     // coverage see primitives submodules and test vectors.
     fn roundtrip_valid_mainnet_addresses() {
-        // A few recent addresses from mainnet (Block 801266).
         let addresses = vec![
-            "bc1q2s3rjwvam9dt2ftt4sqxqjf3twav0gdx0k0q2etxflx38c3x8tnssdmnjq", // Segwit v0
+            "qc1pya3lkjnz85wr9g9cpmn47lr6w7scmcehym0hs335gagppank5emsfw3aee", // Segwit v0
+            // Qtum ToDo
             "bc1py3m7vwnghyne9gnvcjw82j7gqt2rafgdmlmwmqnn3hvcmdm09rjqcgrtxs", // Segwit v1
         ];
 
@@ -451,8 +451,8 @@ mod tests {
 
     fn witness_program() -> [u8; 20] {
         [
-            0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3,
-            0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6,
+            0xf1, 0xb4, 0x3c, 0x26, 0xb1, 0x70, 0x4a, 0xea, 0x71, 0x4b, 0x84, 0x7f, 0x12, 0x01,
+            0x1c, 0x3e, 0x88, 0xd4, 0x69, 0x54,
         ]
     }
 
@@ -460,10 +460,10 @@ mod tests {
     fn encode_lower_to_fmt() {
         let program = witness_program();
         let mut address = String::new();
-        encode_to_fmt_unchecked(&mut address, hrp::BC, VERSION_0, &program)
+        encode_to_fmt_unchecked(&mut address, hrp::QC, VERSION_0, &program)
             .expect("failed to encode address to QR code");
 
-        let want = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+        let want = "qc1q7x6rcf43wp9w5u2ts3l3yqgu86ydg625nf3pft";
         assert_eq!(address, want);
     }
 
@@ -471,10 +471,10 @@ mod tests {
     fn encode_upper_to_fmt() {
         let program = witness_program();
         let mut address = String::new();
-        encode_upper_to_fmt_unchecked(&mut address, hrp::BC, VERSION_0, &program)
+        encode_upper_to_fmt_unchecked(&mut address, hrp::QC, VERSION_0, &program)
             .expect("failed to encode address to QR code");
 
-        let want = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+        let want = "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT";
         assert_eq!(address, want);
     }
 
@@ -483,11 +483,11 @@ mod tests {
     fn encode_lower_to_writer() {
         let program = witness_program();
         let mut buf = Vec::new();
-        encode_lower_to_writer_unchecked(&mut buf, hrp::BC, VERSION_0, &program)
+        encode_lower_to_writer_unchecked(&mut buf, hrp::QC, VERSION_0, &program)
             .expect("failed to encode");
 
         let address = std::str::from_utf8(&buf).expect("ascii is valid utf8");
-        let want = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+        let want = "qc1q7x6rcf43wp9w5u2ts3l3yqgu86ydg625nf3pft";
         assert_eq!(address, want);
     }
 
@@ -496,11 +496,11 @@ mod tests {
     fn encode_upper_to_writer() {
         let program = witness_program();
         let mut buf = Vec::new();
-        encode_upper_to_writer_unchecked(&mut buf, hrp::BC, VERSION_0, &program)
+        encode_upper_to_writer_unchecked(&mut buf, hrp::QC, VERSION_0, &program)
             .expect("failed to encode");
 
         let address = std::str::from_utf8(&buf).expect("ascii is valid utf8");
-        let want = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+        let want = "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT";
         assert_eq!(address, want);
     }
 
@@ -509,20 +509,20 @@ mod tests {
     fn encode_lower_to_writer_including_lowecaseing_hrp() {
         let program = witness_program();
         let mut buf = Vec::new();
-        let hrp = Hrp::parse_unchecked("BC");
+        let hrp = Hrp::parse_unchecked("QC");
         encode_lower_to_writer_unchecked(&mut buf, hrp, VERSION_0, &program)
             .expect("failed to encode");
 
         let address = std::str::from_utf8(&buf).expect("ascii is valid utf8");
-        let want = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+        let want = "qc1q7x6rcf43wp9w5u2ts3l3yqgu86ydg625nf3pft";
         assert_eq!(address, want);
     }
 
     #[test]
     fn encoded_length_works() {
         let addresses = vec![
-            "bc1q2s3rjwvam9dt2ftt4sqxqjf3twav0gdx0k0q2etxflx38c3x8tnssdmnjq",
-            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            "qc1pya3lkjnz85wr9g9cpmn47lr6w7scmcehym0hs335gagppank5emsfw3aee",
+            "qc1q7x6rcf43wp9w5u2ts3l3yqgu86ydg625nf3pft",
         ];
 
         for address in addresses {

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -11,6 +11,7 @@
 //!
 //! ```
 //! # #[cfg(feature = "alloc")] {
+//! use bech32_qtum as bech32;
 //! use bech32::{hrp, segwit, Fe32, Hrp};
 //!
 //! let witness_prog = [
@@ -73,6 +74,7 @@ pub use {
 /// # Examples
 ///
 /// ```
+/// use bech32_qtum as bech32;
 /// use bech32::segwit;
 /// let address = "bc1py3m7vwnghyne9gnvcjw82j7gqt2rafgdmlmwmqnn3hvcmdm09rjqcgrtxs";
 /// let (_hrp, _witness_version, _witness_program) = segwit::decode(address).expect("failed to decode address");

--- a/tests/bip_173_test_vectors.rs
+++ b/tests/bip_173_test_vectors.rs
@@ -85,7 +85,7 @@ macro_rules! check_valid_address_roundtrip {
 }
 // Note these test vectors include various witness versions.
 check_valid_address_roundtrip! {
-    bip_173_valid_address_roundtrip_0, "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+    bip_173_valid_address_roundtrip_0, "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT";
     bip_173_valid_address_roundtrip_1, "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7";
     bip_173_valid_address_roundtrip_2, "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx";
     bip_173_valid_address_roundtrip_3, "BC1SW50QA3JX3S";

--- a/tests/bip_173_test_vectors.rs
+++ b/tests/bip_173_test_vectors.rs
@@ -2,6 +2,7 @@
 
 #![cfg(feature = "alloc")]
 
+use bech32_qtum as bech32;
 use bech32::primitives::decode::{
     CheckedHrpstring, ChecksumError, SegwitHrpstring, UncheckedHrpstring,
 };

--- a/tests/bip_350_test_vectors.rs
+++ b/tests/bip_350_test_vectors.rs
@@ -2,6 +2,7 @@
 
 #![cfg(feature = "alloc")]
 
+use bech32_qtum as bech32;
 use bech32::primitives::decode::{
     CheckedHrpstring, CheckedHrpstringError, ChecksumError, SegwitHrpstring, SegwitHrpstringError,
     UncheckedHrpstring,

--- a/tests/bip_350_test_vectors.rs
+++ b/tests/bip_350_test_vectors.rs
@@ -69,7 +69,7 @@ macro_rules! check_valid_address_roundtrip {
 }
 // Note these test vectors include various witness versions.
 check_valid_address_roundtrip! {
-    bip_350_valid_address_roundtrip_0, "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+    bip_350_valid_address_roundtrip_0, "QC1Q7X6RCF43WP9W5U2TS3L3YQGU86YDG625NF3PFT";
     bip_350_valid_address_roundtrip_1, "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7";
     bip_350_valid_address_roundtrip_2, "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y";
     bip_350_valid_address_roundtrip_3, "BC1SW50QGDZ25J";


### PR DESCRIPTION
This PR adapts the crate to work with Qtum and renames it to `bech32-qtum`.